### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,9 @@ name: PR
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Polandia94/aiointercept/security/code-scanning/2](https://github.com/Polandia94/aiointercept/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/pr.yml` so both jobs inherit least-privilege token access.  
Best fix here (without changing behavior) is to set:

- `contents: read`

This is sufficient for checkout and CI read operations in this workflow. Since neither job needs writes (issues/PR comments/packages/etc.), no extra scopes should be granted.

Edit region: near the top of `.github/workflows/pr.yml`, after the `on:` trigger section and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
