### PR TITLE
add retry on network tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared pytest fixtures and helpers."""
+
+import asyncio
+import functools
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
+
+_RETRY_DELAYS = (None, 1, 2, 4)
+
+
+def network_retry(fn: F) -> F:
+    """Retry an async test on network failure with delays of 1, 3, and 5 seconds."""
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        for delay in _RETRY_DELAYS:
+            if delay is not None:
+                await asyncio.sleep(delay)
+            try:
+                return await fn(*args, **kwargs)
+            except Exception:
+                if delay == _RETRY_DELAYS[-1]:
+                    raise
+
+    return wrapper  # type: ignore[return-value]

--- a/tests/test_aiointercept.py
+++ b/tests/test_aiointercept.py
@@ -11,6 +11,7 @@ import asyncio
 from random import uniform
 
 from aiointercept import aiointercept, CallbackResult
+from tests.conftest import network_retry
 
 # ---------------------------------------------------------------------------
 # Basic mock_external_urls=True (DNS patched) vs False (direct to server)
@@ -285,6 +286,7 @@ async def test_callback_with_payload():
 # ---------------------------------------------------------------------------
 
 
+@network_retry
 async def test_passthrough_host_is_allowed():
     """Passthrough host resolves normally (hits real network)."""
     async with ClientSession() as session:
@@ -312,6 +314,7 @@ async def test_registered_host_missing_path_raises():
 # ---------------------------------------------------------------------------
 
 
+@network_retry
 async def test_passthrough_unmatched_allows_real_requests():
     """Requests without a registered handler pass through to the network."""
     async with ClientSession() as session:
@@ -336,6 +339,7 @@ async def test_passthrough_unmatched_false_raises_for_unknown():
                 await session.get("http://unregistered.test/foo")
 
 
+@network_retry
 async def test_passthrough_unmatched_with_pattern_proxies_unmatched():
     """
     With a pattern registered, DNS redirects ALL hosts to the test server.
@@ -847,6 +851,7 @@ async def test_mock_https_url():
             assert await resp.read() == b"secret"
 
 
+@network_retry
 async def test_passthrough_https_explicit():
     """An https:// URL in the passthrough list reaches the real server with TLS."""
     async with ClientSession() as session:
@@ -860,6 +865,7 @@ async def test_passthrough_https_explicit():
             assert real.status == 201
 
 
+@network_retry
 async def test_passthrough_unmatched_https_no_patterns():
     """With passthrough_unmatched=True and no patterns, HTTPS goes via real DNS directly."""
     async with ClientSession() as session:
@@ -873,6 +879,7 @@ async def test_passthrough_unmatched_https_no_patterns():
             assert real.status == 200
 
 
+@network_retry
 async def test_passthrough_unmatched_https_with_patterns():
     """With patterns active (all DNS redirected), HTTPS passthrough still works.
 

--- a/tests/test_aioresponse.py
+++ b/tests/test_aioresponse.py
@@ -25,6 +25,7 @@ except ImportError:
     )
 
 from aiointercept import CallbackResult, aiointercept
+from tests.conftest import network_retry
 
 from .base import AsyncTestCase
 
@@ -352,6 +353,7 @@ class AIOResponsesTestCase(AsyncTestCase):
                 await coro
             assert str(exception_info.exception) == "Session is closed"
 
+    @network_retry
     async def test_address_as_instance_of_url_combined_with_pass_through(self):
         external_api = "http://httpbin.org/status/201"
 
@@ -369,6 +371,7 @@ class AIOResponsesTestCase(AsyncTestCase):
             self.assertEqual(api.status, 200)
             self.assertEqual(ext.status, 201)
 
+    @network_retry
     async def test_pass_through_with_origin_params(self):
         external_api = "http://httpbin.org/get"
 
@@ -674,6 +677,7 @@ class AIOResponseRedirectTest(AsyncTestCase):
         self.assertEqual(len(response.history), 1)
         self.assertEqual(str(response.history[0].url), url)
 
+    @network_retry
     async def test_pass_through_unmatched_requests(self):
         matched_url = "https://matched_example.org"
         unmatched_url = "https://httpbin.org/get"


### PR DESCRIPTION
there are some tests that are failing with 502 against httpbin on certain runs. so we retry a couple of times.
https://github.com/Polandia94/aiointercept/issues/33