### PR TITLE
add more delays to newtork retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/aiointercept.svg)](https://pypi.org/project/aiointercept/)
 [![Python](https://img.shields.io/pypi/pyversions/aiointercept.svg)](https://pypi.org/project/aiointercept/)
-[![CI](https://github.com/Polandia94/aiointercept/actions/workflows/pr.yml/badge.svg)](https://github.com/Polandia94/aiointercept/actions)
+[![CI](https://github.com/Polandia94/aiointercept/actions/workflows/ci.yml/badge.svg)](https://github.com/Polandia94/aiointercept/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 Mock `aiohttp` HTTP requests by routing them through a real `aiohttp.web` test server. Inspired by `aioresponses`, with a largely compatible API.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,11 @@ from typing import Any, TypeVar
 
 F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
 
-_RETRY_DELAYS = (None, 1, 2, 4)
+_RETRY_DELAYS = (None, 1, 2, 4, 11)
 
 
 def network_retry(fn: F) -> F:
-    """Retry an async test on network failure with delays of 1, 3, and 5 seconds."""
+    """Retry an async test on network failure with delays of 1, 2, 4, and 11 seconds."""
 
     @functools.wraps(fn)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/tests/test_aiointercept.py
+++ b/tests/test_aiointercept.py
@@ -857,12 +857,12 @@ async def test_passthrough_https_explicit():
     """An https:// URL in the passthrough list reaches the real server with TLS."""
     async with (
         ClientSession() as session,
-        aiointercept(mock_external_urls=True, passthrough=["https://httpbin.org/status/201"]) as m,
+        aiointercept(mock_external_urls=True, passthrough=["https://httpbingo.org/status/201"]) as m,
     ):
         m.get("http://example.com/", status=200)
         mocked = await session.get("http://example.com/")
         assert mocked.status == 200
-        real = await session.get("https://httpbin.org/status/201")
+        real = await session.get("https://httpbingo.org/status/201")
         assert real.status == 201
 
 
@@ -873,7 +873,7 @@ async def test_passthrough_unmatched_https_no_patterns():
         m.get("http://example.com/mocked", status=200, body=b"mocked")
         mocked = await session.get("http://example.com/mocked")
         assert mocked.status == 200
-        real = await session.get("https://httpbin.org/status/200")
+        real = await session.get("https://httpbingo.org/status/200")
         assert real.status == 200
 
 
@@ -888,7 +888,7 @@ async def test_passthrough_unmatched_https_with_patterns():
     pattern = re.compile(r"^http://never\.matches/.*$")
     async with ClientSession() as session, aiointercept(mock_external_urls=True, passthrough_unmatched=True) as m:
         m.add(pattern, method="GET", status=200, repeat=True)
-        resp = await session.get("https://httpbin.org/status/200")
+        resp = await session.get("https://httpbingo.org/status/200")
         assert resp.status == 200
 
 

--- a/tests/test_aiointercept.py
+++ b/tests/test_aiointercept.py
@@ -293,12 +293,12 @@ async def test_passthrough_host_is_allowed():
     """Passthrough host resolves normally (hits real network)."""
     async with (
         ClientSession() as session,
-        aiointercept(mock_external_urls=True, passthrough=["http://httpbin.org/status/200"]) as m,
+        aiointercept(mock_external_urls=True, passthrough=["http://httpbingo.org/status/200"]) as m,
     ):
         m.get("http://example.com/", status=200)
         mocked = await session.get("http://example.com/")
         assert mocked.status == 200
-        real = await session.get("http://httpbin.org/status/200")
+        real = await session.get("http://httpbingo.org/status/200")
         assert real.status == 200
 
 
@@ -322,7 +322,7 @@ async def test_passthrough_unmatched_allows_real_requests():
         m.get("http://example.com/mocked", status=200, body=b"mocked")
         mocked = await session.get("http://example.com/mocked")
         assert mocked.status == 200
-        real = await session.get("http://httpbin.org/status/201")
+        real = await session.get("http://httpbingo.org/status/201")
         assert real.status == 201
 
 
@@ -349,7 +349,7 @@ async def test_passthrough_unmatched_with_pattern_proxies_unmatched():
         resp_mocked = await session.get("http://pat.test/specific")
         assert resp_mocked.status == 200
         # Unmatched: proxied via real DNS to the actual server
-        resp_real = await session.get("http://httpbin.org/status/201")
+        resp_real = await session.get("http://httpbingo.org/status/201")
         assert resp_real.status == 201
 
 
@@ -1218,11 +1218,11 @@ async def test_passthrough_unmatched_url_handler_unknown_path_proxied():
     unregistered path on a registered host is proxied to the real server, not
     closed with ClientConnectionError."""
     async with ClientSession() as session, aiointercept(mock_external_urls=True, passthrough_unmatched=True) as m:
-        m.get("http://httpbin.org/status/200", status=418)
-        mocked = await session.get("http://httpbin.org/status/200")
+        m.get("http://httpbingo.org/status/200", status=418)
+        mocked = await session.get("http://httpbingo.org/status/200")
         assert mocked.status == 418
         # Same host, different path — should proxy to real httpbin, not close.
-        real = await session.get("http://httpbin.org/status/201")
+        real = await session.get("http://httpbingo.org/status/201")
         assert real.status == 201
 
 

--- a/tests/test_aioresponse.py
+++ b/tests/test_aioresponse.py
@@ -212,7 +212,7 @@ class AIOResponsesTestCase(AsyncTestCase):
         # Wrong url
         with self.assertRaises(AssertionError):
             m.assert_called_once_with(
-                "http://httpbin.org/",
+                "http://httpbingo.org/",
                 method="POST",
                 data=payload,
                 headers={"User-Agent": "aiointercept"},
@@ -352,7 +352,7 @@ class AIOResponsesTestCase(AsyncTestCase):
 
     @network_retry
     async def test_address_as_instance_of_url_combined_with_pass_through(self):
-        external_api = "http://httpbin.org/status/201"
+        external_api = "http://httpbingo.org/status/201"
 
         async def doit():
             api_resp = await self.session.get(self.url)
@@ -370,7 +370,7 @@ class AIOResponsesTestCase(AsyncTestCase):
 
     @network_retry
     async def test_pass_through_with_origin_params(self):
-        external_api = "http://httpbin.org/get"
+        external_api = "http://httpbingo.org/get"
 
         async def doit(params):
             # we have to hit actual url,
@@ -382,7 +382,7 @@ class AIOResponsesTestCase(AsyncTestCase):
             params = {"foo": "bar"}
             ext = await doit(params=params)
             self.assertEqual(ext.status, 200)
-            self.assertEqual(str(ext.url), "http://httpbin.org/get?foo=bar")
+            self.assertEqual(str(ext.url), "http://httpbingo.org/get?foo=bar")
 
     @aiointercept(True)
     async def test_custom_response_class(self, m):
@@ -504,7 +504,7 @@ class AIOResponsesTestCase(AsyncTestCase):
 
     @aiointercept(True)
     async def test_assert_any_call(self, m: aiointercept):
-        http_bin_url = "http://httpbin.org"
+        http_bin_url = "http://httpbingo.org"
         m.get(self.url)
         m.get(http_bin_url)
         await self.session.get(self.url)
@@ -515,7 +515,7 @@ class AIOResponsesTestCase(AsyncTestCase):
 
     @aiointercept(True)
     async def test_assert_any_call_not_called(self, m: aiointercept):
-        http_bin_url = "http://httpbin.org"
+        http_bin_url = "http://httpbingo.org"
         m.get(self.url)
         response = await self.session.get(self.url)
         self.assertEqual(response.status, 200)

--- a/tests/test_aioresponse.py
+++ b/tests/test_aioresponse.py
@@ -596,12 +596,12 @@ class AIOResponseRedirectTest(AsyncTestCase):
         rsps.get(
             self.url,
             status=307,
-            headers={"Location": "https://httpbin.org"},
+            headers={"Location": "https://httpbingo.org"},
         )
-        rsps.get("https://httpbin.org")
+        rsps.get("https://httpbingo.org")
         response = await self.session.get(self.url, allow_redirects=True)
         self.assertEqual(response.status, 200)
-        self.assertEqual(str(response.url), "https://httpbin.org")
+        self.assertEqual(str(response.url), "https://httpbingo.org")
         self.assertEqual(len(response.history), 1)
         self.assertEqual(str(response.history[0].url), self.url)
 
@@ -610,12 +610,12 @@ class AIOResponseRedirectTest(AsyncTestCase):
         rsps.post(
             self.url,
             status=302,
-            headers={"Location": "https://httpbin.org"},
+            headers={"Location": "https://httpbingo.org"},
         )
-        rsps.get("https://httpbin.org")
+        rsps.get("https://httpbingo.org")
         response = await self.session.post(self.url, allow_redirects=True)
         self.assertEqual(response.status, 200)
-        self.assertEqual(str(response.url), "https://httpbin.org")
+        self.assertEqual(str(response.url), "https://httpbingo.org")
         self.assertEqual(response.method, "GET")
         self.assertEqual(len(response.history), 1)
         self.assertEqual(str(response.history[0].url), self.url)
@@ -625,7 +625,7 @@ class AIOResponseRedirectTest(AsyncTestCase):
         rsps.get(
             self.url,
             status=307,
-            headers={"Location": "https://httpbin.org"},
+            headers={"Location": "https://httpbingo.org"},
         )
         with self.assertRaises(ClientConnectionError):
             await self.session.get(self.url, allow_redirects=True)
@@ -658,7 +658,7 @@ class AIOResponseRedirectTest(AsyncTestCase):
 
     @aiointercept(True)
     async def test_relative_url_redirect_followed(self, rsps):
-        base_url = "https://httpbin.org"
+        base_url = "https://httpbingo.org"
         url = f"{base_url}/foo/bar"
         rsps.get(
             url,
@@ -677,7 +677,7 @@ class AIOResponseRedirectTest(AsyncTestCase):
     @network_retry
     async def test_pass_through_unmatched_requests(self):
         matched_url = "https://matched_example.org"
-        unmatched_url = "https://httpbin.org/get"
+        unmatched_url = "https://httpbingo.org/get"
         params_unmatched = {"foo": "bar"}
 
         async with aiointercept(True, passthrough_unmatched=True) as m:
@@ -687,7 +687,7 @@ class AIOResponseRedirectTest(AsyncTestCase):
                 URL(unmatched_url), params=params_unmatched
             )
             self.assertEqual(response.status, 200)
-            self.assertEqual(str(response.url), "https://httpbin.org/get?foo=bar")
+            self.assertEqual(str(response.url), "https://httpbingo.org/get?foo=bar")
             self.assertEqual(mocked_response.status, 200)
 
 


### PR DESCRIPTION
in some cases httpbin is failing the 3 requests. As we need ssl requests, there is no easy way to do this with the httpbin docker. chang httpbin to httpbingo (looks more stable)