### PR TITLE
fix: regex callback receive real url and content type header on call back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Unreleased
+
+### Fixed
+
+- Callbacks were receiving the compiled regex instead of the real URL; now every callback receives a yarl `URL`.
+- Callbacks with a `Content-Type` header were raising an exception (the header collided with the default content type); now fixed.
 
 ## [0.1.6] - 2026-06-09
 

--- a/aiointercept/core.py
+++ b/aiointercept/core.py
@@ -46,10 +46,15 @@ class AiointerceptRequest(web.Request):
         kwargs: A mapping with the parsed ``headers``, ``query`` (``dict`` of
             key → list of values), and ``json`` (decoded body, or ``None``) —
             the keyword arguments a callback receives.
+        canonical_url: The normalized request URL with the original scheme
+            restored (e.g. ``https://`` even though the test server received the
+            request over plain HTTP). This is the URL passed to callbacks and
+            used as the :attr:`aiointercept.requests` key.
     """
 
     captured_body: bytes
     kwargs: AiointerceptRequestKwargs
+    canonical_url: URL
 
     @classmethod
     def upgrade(
@@ -57,10 +62,12 @@ class AiointerceptRequest(web.Request):
         request: web.Request,
         captured_body: bytes,
         kwargs: "AiointerceptRequestKwargs",
+        canonical_url: URL,
     ) -> "AiointerceptRequest":
         request.__class__ = cls
         request.captured_body = captured_body  # type: ignore[attr-defined]
         request.kwargs = kwargs  # type: ignore[attr-defined]
+        request.canonical_url = canonical_url  # type: ignore[attr-defined]
         return cast("AiointerceptRequest", request)
 
 
@@ -81,12 +88,15 @@ _active_instances: "list[aiointercept]" = []
 _tcp_connectors: "weakref.WeakSet[TCPConnector]" = weakref.WeakSet()
 _original_tcp_connector_init = TCPConnector.__init__
 
+
 @wraps(_original_tcp_connector_init)
 def _patched_tcp_connector_init(self: "TCPConnector", *args: Any, **kwargs: Any) -> None:
     _original_tcp_connector_init(self, *args, **kwargs)
     _tcp_connectors.add(self)
 
-TCPConnector.__init__ = _patched_tcp_connector_init # type: ignore[method-assign]
+
+TCPConnector.__init__ = _patched_tcp_connector_init  # type: ignore[method-assign]
+
 
 def _make_resolve_result(host: str, inst: "aiointercept", family: "socket.AddressFamily") -> "ResolveResult":
     return ResolveResult(
@@ -157,7 +167,9 @@ class CallbackResult:
         method: HTTP method (default GET; not used by the server handler).
         status: HTTP response status code.
         body: Raw response body as str or bytes.
-        content_type: ``Content-Type`` header value.
+        content_type: ``Content-Type`` header value. Set to ``None`` when
+            *headers* already carries a ``Content-Type`` entry, to avoid
+            colliding with it.
         payload: Response body as a dict; serialized to JSON automatically.
         headers: Additional response headers.
         response_class: Ignored (present for aioresponses API compatibility).
@@ -178,8 +190,12 @@ class CallbackResult:
         self.method = method
         self.status = status
         self.body = body
-        self.content_type = content_type
         self.payload = payload
+        # Drop the default content_type when the caller already supplied a
+        # Content-Type header (case-insensitively), to avoid the ValueError
+        # aiohttp.web.Response raises when both are set.
+        has_content_type_header = headers is not None and any(k.lower() == "content-type" for k in headers)
+        self.content_type: str | None = None if has_content_type_header else content_type
         self.headers = headers
         self.response_class = response_class
         self.reason = reason
@@ -537,7 +553,7 @@ class aiointercept:  # noqa: N801
             "json": json,
         }
 
-        aiointercept_request = AiointerceptRequest.upgrade(request, captured_body, request_kwargs)
+        aiointercept_request = AiointerceptRequest.upgrade(request, captured_body, request_kwargs, url)
         # Read body eagerly before the handler runs, because aiohttp sets
         # PayloadAccessError on the stream once the response cycle completes.
         self.requests[key].append(aiointercept_request)
@@ -677,12 +693,17 @@ class aiointercept:  # noqa: N801
             body = body.encode()
 
         resp_headers = dict(headers or {})
-        if not content_type and "Content-Type" not in resp_headers:
+        if not content_type and not any(k.lower() == "content-type" for k in resp_headers):
             content_type = "application/json"
 
         async def handler(request: web.Request) -> web.Response:
             if callable(callback):
-                cb_kwargs = cast("AiointerceptRequest", request).kwargs
+                aiointercept_request = cast("AiointerceptRequest", request)
+                cb_kwargs = aiointercept_request.kwargs
+                # Use the canonical URL (normalized, original scheme restored)
+                # rather than request.url, which is always http:// here because
+                # the test server receives the request over plain HTTP.
+                cb_url = aiointercept_request.canonical_url
                 if inspect.iscoroutinefunction(callback):
                     # Async callbacks run on the caller's loop so that
                     # loop-bound primitives (asyncio.Event, asyncio.Queue,
@@ -694,12 +715,12 @@ class aiointercept:  # noqa: N801
                         and caller_loop is not asyncio.get_running_loop()
                     ):
                         result = await asyncio.wrap_future(
-                            asyncio.run_coroutine_threadsafe(callback(url, **cb_kwargs), caller_loop)
+                            asyncio.run_coroutine_threadsafe(callback(cb_url, **cb_kwargs), caller_loop)
                         )
                     else:
-                        result = await callback(url, **cb_kwargs)
+                        result = await callback(cb_url, **cb_kwargs)
                 else:
-                    result = callback(url, **cb_kwargs)
+                    result = callback(cb_url, **cb_kwargs)
                 _status = result.status
                 _body = result.body
                 _headers = result.headers or {}

--- a/tests/test_aiointercept.py
+++ b/tests/test_aiointercept.py
@@ -1116,6 +1116,97 @@ async def test_callback_result_headers():
         assert resp.headers.get("X-From-Callback") == "yes"
 
 
+async def test_regex_callback_receives_actual_url():
+    """A callback registered with a regex pattern must receive the request URL,
+    not the compiled re.Pattern it was registered with."""
+    seen = {}
+
+    def callback(url, **kwargs):
+        seen["url"] = url
+        return CallbackResult(payload={"ok": True})
+
+    async with aiointercept(mock_external_urls=True) as m:
+        m.get(re.compile(r"http://example\.test/api/.*"), callback=callback)
+        async with aiohttp.ClientSession() as session, session.get("http://example.test/api/status") as resp:
+            assert await resp.json() == {"ok": True}
+
+    assert isinstance(seen["url"], URL)
+    assert str(seen["url"]) == "http://example.test/api/status"
+
+
+async def test_callback_result_content_type_header():
+    """A CallbackResult carrying an explicit Content-Type header must not collide
+    with the default content_type and trigger an internal server error."""
+
+    def callback(url, **kwargs):
+        return CallbackResult(
+            body=b"hello",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+    async with aiointercept(mock_external_urls=True) as m:
+        m.get("http://example.test/file", callback=callback)
+        async with aiohttp.ClientSession() as session, session.get("http://example.test/file") as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("application/octet-stream")
+            assert await resp.read() == b"hello"
+
+
+async def test_callback_result_content_type_header_case_insensitive():
+    """A lower-cased content-type header must also be detected so it does not
+    collide with the default content_type."""
+
+    def callback(url, **kwargs):
+        return CallbackResult(
+            body=b"hello",
+            headers={"content-type": "application/octet-stream"},
+        )
+
+    async with aiointercept(mock_external_urls=True) as m:
+        m.get("http://example.test/file", callback=callback)
+        async with aiohttp.ClientSession() as session, session.get("http://example.test/file") as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("application/octet-stream")
+            assert await resp.read() == b"hello"
+
+
+async def test_https_callback_receives_https_url():
+    """Under mock_external_urls=True, a callback for an https:// URL must receive
+    a URL carrying the https:// scheme — not the http:// the test server saw."""
+    seen = {}
+
+    def callback(url, **kwargs):
+        seen["url"] = url
+        return CallbackResult(payload={"ok": True})
+
+    async with aiointercept(mock_external_urls=True) as m:
+        m.get("https://secure.test/api/status", callback=callback)
+        async with aiohttp.ClientSession() as session, session.get("https://secure.test/api/status") as resp:
+            assert await resp.json() == {"ok": True}
+
+    assert isinstance(seen["url"], URL)
+    assert seen["url"].scheme == "https"
+    assert str(seen["url"]) == "https://secure.test/api/status"
+
+
+async def test_https_regex_callback_receives_https_url():
+    """A regex callback matching an https:// URL must also receive the https:// scheme."""
+    seen = {}
+
+    def callback(url, **kwargs):
+        seen["url"] = url
+        return CallbackResult(payload={"ok": True})
+
+    async with aiointercept(mock_external_urls=True) as m:
+        m.get(re.compile(r"https://secure\.test/api/.*"), callback=callback)
+        async with aiohttp.ClientSession() as session, session.get("https://secure.test/api/status") as resp:
+            assert await resp.json() == {"ok": True}
+
+    assert isinstance(seen["url"], URL)
+    assert seen["url"].scheme == "https"
+    assert str(seen["url"]) == "https://secure.test/api/status"
+
+
 # ---------------------------------------------------------------------------
 # exception=True (no log warning) vs exception=SomeInstance (with log warning)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fix #75 