### PR TITLE
Populate data kwarg for non-JSON requests

### DIFF
--- a/aiointercept/core.py
+++ b/aiointercept/core.py
@@ -8,6 +8,7 @@ import threading
 import typing
 import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import suppress
 from functools import wraps
 from re import Pattern
 from typing import Any, TypedDict, cast
@@ -29,6 +30,7 @@ class AiointerceptRequestKwargs(TypedDict):
     headers: Mapping[str, str]
     query: Mapping[str, Sequence[str]]
     json: Any | None
+    data: bytes | None
 
 
 class AiointerceptRequest(web.Request):
@@ -59,7 +61,7 @@ class AiointerceptRequest(web.Request):
     def upgrade(
         cls,
         request: web.Request,
-        captured_body: bytes,
+        captured_body: bytes | None,
         kwargs: "AiointerceptRequestKwargs",
         canonical_url: URL,
     ) -> "AiointerceptRequest":
@@ -582,17 +584,19 @@ class aiointercept:  # noqa: N801
 
         key = (request.method.upper(), url)
         self.requests.setdefault(key, [])
-        captured_body = await request.read() if request.can_read_body else b""
-        try:
-            json = json_module.loads(captured_body) if captured_body else None
-        except Exception:
-            json = None
+        captured_body = None
+        json = None
+        if request.can_read_body:
+            captured_body = await request.read()
+            with suppress(Exception):
+                json = json_module.loads(captured_body) if captured_body else None
         # this kwargs will be removed, should be deprecated in the future
         request_kwargs: AiointerceptRequestKwargs = {
             "headers": request.headers,
             # Use getall so duplicate keys (?a=1&a=2) aren't collapsed to one value.
             "query": {k: request.query.getall(k) for k in dict.fromkeys(request.query)},
             "json": json,
+            "data": captured_body,
         }
 
         aiointercept_request = AiointerceptRequest.upgrade(request, captured_body, request_kwargs, url)


### PR DESCRIPTION
Hey, thanks for patching my issues from yesterday so quickly!

I ran into one more thing today.

> **Migrating - Differences to be aware of**
> Callbacks only receive headers, query, and json (no client-side kwargs)

This is a known difference vs aioresponses but in my case my test suite needs access to the `data` kwarg to access the raw body data - it is not JSON-encoded. I looked at the aiointercept codebase and this turned out to only require a very minor change so I think it would be nice to provide.

The only thing I'm not sure of is whether to do `bytes | None` or just `bytes` and default to `b''` . It would be nice for the data kwarg to contain None if no data was explicitly provided which is why I went with the current approach.

I don't see any downsides to supporting this, but let me know if you feel otherwise.