### PR TITLE
Allow request bodies larger than 1 MiB

### DIFF
--- a/aiointercept/core.py
+++ b/aiointercept/core.py
@@ -537,7 +537,9 @@ class aiointercept:  # noqa: N801
             self._server_loop = loop
 
             async def _start_server() -> None:
-                app = web.Application()
+                # aiohttp's default 1 MiB cap rejects uploads before the mock handler
+                # can respond, even if the real service would accept them.
+                app = web.Application(client_max_size=0)
                 app.router.add_route("*", "/{tail:.*}", self._dispatch)
                 self.server = TestServer(app)
                 await self.server.start_server()

--- a/tests/test_aiointercept.py
+++ b/tests/test_aiointercept.py
@@ -6,6 +6,7 @@ import logging
 import re
 import socket
 import threading
+from io import BytesIO
 from random import uniform
 from unittest import mock
 
@@ -1981,10 +1982,10 @@ async def test_streaming_response_body():
 # ---------------------------------------------------------------------------
 
 
-async def test_streaming_request_body():
-    """Client sends an async-generator body (chunked transfer encoding); the
-    mock server assembles all pieces and exposes the full body via captured_body."""
-    parts = [b"part-A", b"part-B", b"part-C"]
+@pytest.mark.parametrize("chunked", [False, True], ids=["fixed-length", "chunked"])
+async def test_large_request_body(chunked: bool) -> None:
+    """Bodies larger than 1 MiB reach the handler and are captured in full."""
+    parts = [b"a" * (512 * 1024), b"b" * (512 * 1024), b"c" * (512 * 1024)]
 
     async def body_gen():
         for part in parts:
@@ -1992,7 +1993,7 @@ async def test_streaming_request_body():
 
     async with ClientSession() as session, aiointercept(mock_external_urls=True) as m:
         m.post("http://stream.test/upload", status=200)
-        resp = await session.post("http://stream.test/upload", data=body_gen())
+        resp = await session.post("http://stream.test/upload", data=body_gen() if chunked else BytesIO(b"".join(parts)))
         assert resp.status == 200
 
     assert m.last_request is not None


### PR DESCRIPTION
The test server inherits aiohttp’s 1 MiB request-body limit[1]. Larger
uploads return HTTP 413 while their bodies are read, before the
registered mock handler can run.

Disable that cap on the interception application. Extend the existing
streaming-request test to cover fixed-length and chunked uploads above
1 MiB and verify complete body capture.

[1]: https://docs.aiohttp.org/en/v3.13.3/web_reference.html#aiohttp.web.Application