### PR TITLE
Potential fix for code scanning alert no. 3: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/aiohttp-main.yml
+++ b/.github/workflows/aiohttp-main.yml
@@ -6,10 +6,6 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
-      aiohttp_ref:
-        description: "aiohttp branch / tag / commit to test against"
-        default: "master"
-        required: false
       aiointercept_ref:
         description: "aiointercept branch / tag / commit to check out (leave blank for default branch)"
         default: ""
@@ -36,11 +32,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --group tests
 
-      - name: Check out aiohttp ${{ inputs.aiohttp_ref || 'master' }}
+      - name: Check out aiohttp master
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: aio-libs/aiohttp
-          ref: ${{ inputs.aiohttp_ref || 'master' }}
+          ref: master
           path: aiohttp-src
           submodules: recursive
 


### PR DESCRIPTION
Fix for [https://github.com/Polandia94/aiointercept/security/code-scanning/3](https://github.com/Polandia94/aiointercept/security/code-scanning/3)

Avoid run check with aiohttp non-master branchs, as can contain untrusted code. If we need to test against a specific pre-release brnach or similar we can add directly to the workflow or test locally
